### PR TITLE
Make the output easier to configure.

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,38 +129,42 @@ scenario("This is my scenario", {
 });
 ```
 
-## Custom logger
+## Custom formatter
 
 ```javascript
-var myCoolLogger = {
-  // Summary and pending tests.
-  "warn":   function(msg){},
-  // When good things happend.
-  "log":    function(msg){},
-  // The header of the test.
-  "info":   function(msg){},
-  // When bad things happend
-  "error":  function(msg){
-    alert(msg);
-  },
+var myCoolFormatter = {
+  // Passing tests
+  "ok": function(msg) {},
+
+  // Failing tests
+  "fail": function(msg) {},
+
+  // Pending tests
+  "pending": function(msg) {},
+
+  // The start of a scenario
+  "scenario": function(msg) {},
+
+  // Report at the end of a scenario
+  "summary": function(msg) {}
 };
 
 scenario("Fancy scenario", {
   "somewhere over the rainbow": function(g) {
     g.assert(false);
   }
-}, myCoolLogger);
+}, myCoolFormatter);
 
 // Or if you want to affect every gerbil scenario
 
-Gerbil.logger = myCoolLogger;
+Gerbil.formatter = myCoolFormatter;
 ```
 
 ## What's the catch?
 
 The results are only shown in the console, the one from console.log if you use
 it in a browser.
-Run it with an open inspector or define a custom logger if you want prettier
+Run it with an open inspector or define a custom formatter if you want prettier
 results.
 And in the bottom you will find the summary
 

--- a/lib/gerbil.js
+++ b/lib/gerbil.js
@@ -1,9 +1,9 @@
-var Gerbil = function Gerbil(description, tests, logger) {
+var Gerbil = function Gerbil(description, tests, formatter) {
   this.success = 0;
   this.failures = 0;
   this.count = 0;
   this.timeout = 0;
-  this.logger = typeof logger == 'object' ? logger : Gerbil.logger;
+  this.formatter = typeof formatter == 'object' ? formatter : Gerbil.formatter;
   this.queue = new Gerbil.Queue;
   this.results = new Gerbil.Queue;
   this.description = description;
@@ -28,16 +28,16 @@ var Gerbil = function Gerbil(description, tests, logger) {
 
   this.ok = function(test) {
     this.success++;
-    test.scenario.logger.log(Gerbil.format("   * {0} ({1} assertions)", [test.name, test.assertions]));
+    test.scenario.formatter.ok(Gerbil.format("{0} ({1} assertions)", [test.name, test.assertions]));
   };
 
   this.fail = function(test) {
     this.failures++;
-    test.scenario.logger.error(Gerbil.format("   x {0} - assertion number {1} failed - {2}", [test.name, test.assertions + 1, test.message]));
+    test.scenario.formatter.fail(Gerbil.format("{0} - assertion number {1} failed - {2}", [test.name, test.assertions + 1, test.message]));
   };
 
   this.postergate = function(test) {
-    test.scenario.logger.warn("   ! " + test.message);
+    test.scenario.formatter.pending(test.message);
   };
 
   this.enqueue = function() {
@@ -95,7 +95,7 @@ var Gerbil = function Gerbil(description, tests, logger) {
     var assertions = 0;
     var elapsedTime = 0;
 
-    this.logger.info("== Running " + this.description + " ==");
+    this.formatter.scenario(this.description);
 
     do {
       test = this.results.pull();
@@ -109,8 +109,7 @@ var Gerbil = function Gerbil(description, tests, logger) {
         }
       }
     } while(test);
-    this.logger.warn(Gerbil.format("All tests completed for {0}: {1} passed, {2} failed of {3} tests ({4} assertions) in {5} s", [this.description, this.success, this.failures, this.count, assertions, elapsedTime]));
-    this.logger.info("");
+    this.formatter.summary(Gerbil.format("All tests completed for {0}: {1} passed, {2} failed of {3} tests ({4} assertions) in {5} s", [this.description, this.success, this.failures, this.count, assertions, elapsedTime]));
   };
 
   this.enqueue();
@@ -246,7 +245,7 @@ Gerbil.Test.prototype = {
   }
 };
 
-Gerbil.Logger = {
+Gerbil.Console = {
   pretty: {
     log: function(msg) { return console.log("\033[32m" + msg + "\033[0m"); },
     info: function(msg) { return console.info("\033[34m" + msg + "\033[0m"); },
@@ -257,10 +256,29 @@ Gerbil.Logger = {
   simple: console
 };
 
-Gerbil.logger = Gerbil.IS_NODE ? Gerbil.Logger.pretty : Gerbil.Logger.simple;
+Gerbil.console = Gerbil.IS_NODE ? Gerbil.Console.pretty : Gerbil.Console.simple;
 
-Gerbil.scenario = function scenario(description, tests, logger) {
-  return new Gerbil(description, tests, logger).run();
+Gerbil.formatter = {
+  ok: function(msg) {
+    Gerbil.console.log("   * " + msg);
+  },
+  fail: function(msg) {
+    Gerbil.console.error("   x " + msg);
+  },
+  pending: function(msg) {
+    Gerbil.console.warn("   ! " + msg);
+  },
+  scenario: function(msg) {
+    Gerbil.console.info("== Running " + msg + " ==")
+  },
+  summary: function(msg) {
+    Gerbil.console.warn(msg);
+    Gerbil.console.info("");
+  }
+}
+
+Gerbil.scenario = function scenario(description, tests, formatter) {
+  return new Gerbil(description, tests, formatter).run();
 };
 
 if(Gerbil.IS_NODE) {

--- a/test/gerbil.html
+++ b/test/gerbil.html
@@ -7,15 +7,39 @@
       var runTests = function() {
         var results = document.querySelector("#results");
         var ul = false;
+        var pre = document.createElement("pre");
         var prettyPrint = {
-          log: function(msg) {
+          ok: function(msg) {
             var li = document.createElement("li");
             li.className = "ok"
 
-            li.textContent = msg;
+            var content = pre.cloneNode();
+            content.textContent = msg;
+
+            li.appendChild(content);
             ul.appendChild(li);
           },
-          info: function(msg) {
+          pending: function(msg) {
+            var li = document.createElement("li");
+            li.className = "pending"
+
+            var content = pre.cloneNode();
+            content.textContent = msg;
+
+            li.appendChild(content);
+            ul.appendChild(li);
+         },
+          fail: function(msg) {
+            var li = document.createElement("li");
+            li.className = "error"
+
+            var content = pre.cloneNode();
+            content.textContent = msg;
+
+            li.appendChild(content);
+            ul.appendChild(li);
+         },
+          scenario: function(msg) {
             var h1 = document.createElement("h1");
             ul = document.createElement("ul");
 
@@ -23,27 +47,23 @@
             results.appendChild(h1);
             results.appendChild(ul);
           },
-          warn: function(msg) {
+          summary: function(msg) {
             var h2 = document.createElement("h2");
             h2.textContent = msg;
             results.appendChild(h2);
           },
-          error: function(msg) {
-            var li = document.createElement("li");
-
-            li.className = "error"
-            li.textContent = msg;
-            ul.appendChild(li);
-         },
         };
 
-        Gerbil.logger = prettyPrint;
+        Gerbil.formatter = prettyPrint;
 
         scenario("Showing a pretty print for the tests", {
           "setup": function() {
           },
           "it should show a success message": function(g) {
             g.assert(true);
+          },
+          "it should show a postergated test": function(g) {
+            g.pending("this test is pending");
           },
           "it should show an error message": function(g) {
             g.assert(false);
@@ -54,6 +74,7 @@
     <style type="text/css">
       li { list-style-type: none }
       .error { color: red; }
+      .pending { color: #ffaa00; }
       .ok { color: green; }
     </style>
   </head>


### PR DESCRIPTION
Introduce Gerbil.formatter instead of Gerbil.logger. This object has the
following methods:
- ok (for successful tests)
- fail (for failed tests)
- pending (for pending tests)
- scenario (for scenario headings)
- summary (for scenario summaries)
