### PR TITLE
More flexible summaries

### DIFF
--- a/lib/gerbil.js
+++ b/lib/gerbil.js
@@ -111,7 +111,16 @@ var Gerbil = function Gerbil(description, tests, formatter) {
         }
       }
     } while(test);
-    this.formatter.summary(Gerbil.format("All tests completed for {0}: {1} passed, {2} failed, {3} pending of {4} tests ({5} assertions) in {6} s", [this.description, this.success, this.failures, this.count, assertions, elapsedTime]));
+
+    this.formatter.summary({
+      description: this.description,
+      pass:        this.success,
+      fail:        this.failures,
+      pending:     this.pending,
+      total:       this.count,
+      assertions:  assertions,
+      time:        elapsedTime
+    });
   };
 
   this.enqueue();
@@ -279,8 +288,17 @@ Gerbil.formatter = {
   scenario: function(msg) {
     Gerbil.console.info("== Running " + msg + " ==");
   },
-  summary: function(msg) {
-    Gerbil.console.warn(msg);
+  summary: function(summary) {
+    var summaryString = Gerbil.format("All tests completed for {0}: {1} passed, {2} failed, {3} pending, of {4} tests ({5} assertions) in {6} s", [
+      summary.description,
+      summary.pass,
+      summary.fail,
+      summary.pending,
+      summary.total,
+      summary.assertions,
+      summary.time
+    ]);
+    Gerbil.console.warn(summaryString);
     Gerbil.console.info("");
   }
 };

--- a/lib/gerbil.js
+++ b/lib/gerbil.js
@@ -1,5 +1,6 @@
 var Gerbil = function Gerbil(description, tests, formatter) {
   this.success = 0;
+  this.pending = 0;
   this.failures = 0;
   this.count = 0;
   this.timeout = 0;
@@ -37,6 +38,7 @@ var Gerbil = function Gerbil(description, tests, formatter) {
   };
 
   this.postergate = function(test) {
+    this.pending++;
     test.scenario.formatter.pending(test.message);
   };
 
@@ -109,7 +111,7 @@ var Gerbil = function Gerbil(description, tests, formatter) {
         }
       }
     } while(test);
-    this.formatter.summary(Gerbil.format("All tests completed for {0}: {1} passed, {2} failed of {3} tests ({4} assertions) in {5} s", [this.description, this.success, this.failures, this.count, assertions, elapsedTime]));
+    this.formatter.summary(Gerbil.format("All tests completed for {0}: {1} passed, {2} failed, {3} pending of {4} tests ({5} assertions) in {6} s", [this.description, this.success, this.failures, this.count, assertions, elapsedTime]));
   };
 
   this.enqueue();


### PR DESCRIPTION
- Keep track of how many pending tests there are
- Instead of passing a string to Formatter.summary, pass an object with the data, and let the formatter choose how to display it.
