### PR TITLE
assertThrow should rise an error if expected and thrown errors don't match

### DIFF
--- a/lib/gerbil.js
+++ b/lib/gerbil.js
@@ -260,7 +260,7 @@ Gerbil.Test.prototype = {
       fn();
       errorMessage = expectedError.name + " was expected but not raised.";
     } catch(exception) {
-      if (typeof exception === typeof expectedError) {
+      if (!(exception instanceof expectedError)) {
         errorMessage = expectedError.name + " was expected but " + exception.name + " was raised.";
       }
     }

--- a/test/gerbil.js
+++ b/test/gerbil.js
@@ -30,7 +30,19 @@ scenario("Gerbil - Assertions", {
     g.assertThrow(Error, function() {
       g.assertType(Function, 42);
     });
-  }
+  },
+
+  "should rise an error if expected and thrown errors don't match": function(g) {
+    function CustomError1() {}
+    function CustomError2() {}
+
+    g.assertThrow(Error, function() {
+      g.assertThrow(CustomError1, function(){
+        throw new CustomError2();
+      });
+    });
+  },
+
 });
 
 scenario("Gerbil - setTimeout", {


### PR DESCRIPTION
Having the following code:

``` javascript
function CustomError1() {}
function CustomError2() {}
g.assertThrow(CustomError1, function(){
  throw new CustomError2();
});
```

Gerbil should rise an error.

This commit solves the problem, by failing if the thrown exception is not an instance of the expected error.
